### PR TITLE
extensions.js: Fix warning about incompat args for signal_subscribe

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -195,9 +195,7 @@ var Kimpanel = new Lang.Class({
             null,
             null,
             Gio.DBusSignalFlags.NONE,
-            _parseSignal,
-            null,
-            null
+            _parseSignal
         );
         this.owner_id = Gio.bus_own_name(Gio.BusType.SESSION,
                                          "org.kde.impanel",


### PR DESCRIPTION
Ref: http://devdocs.baznga.org/gio20~2.50p/gio.dbusconnection#method-signal_subscribe

Only 7 args are accepted, not 9.