### PR TITLE
install.sh: Mention gnome-tweaks as well

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,4 +21,4 @@ make clean || error
 make install-zip || error
 
 echo "Install successfull!"
-echo "Enable it with gnome-tweak-tool"
+echo "Enable it with gnome-tweak-tool or gnome-tweaks"


### PR DESCRIPTION
New version of GNOME renamed gnome-tweak-tool to gnome-tweaks.
This commit would mention both names so that users may choose
either one based on their systems.